### PR TITLE
Night mode for OV2640 (inspired by Tasmota)

### DIFF
--- a/esphome/components/esp32_camera/__init__.py
+++ b/esphome/components/esp32_camera/__init__.py
@@ -285,7 +285,7 @@ async def to_code(config):
     cg.add_define("USE_ESP32_CAMERA")
 
     if CORE.using_esp_idf:
-        cg.add_library("misch2/esp32-camera", "ov2640-nightmode")
+        cg.add_library("espressif/esp32-camera", "1.0.0")
         add_idf_sdkconfig_option("CONFIG_RTCIO_SUPPORT_RTC_GPIO_DESC", True)
 
     for conf in config.get(CONF_ON_STREAM_START, []):

--- a/esphome/components/esp32_camera/__init__.py
+++ b/esphome/components/esp32_camera/__init__.py
@@ -279,7 +279,7 @@ async def to_code(config):
     cg.add_define("USE_ESP32_CAMERA")
 
     if CORE.using_esp_idf:
-        cg.add_library("espressif/esp32-camera", "1.0.0")
+        cg.add_library("misch2/esp32-camera", "ov2640-nightmode")
         add_idf_sdkconfig_option("CONFIG_RTCIO_SUPPORT_RTC_GPIO_DESC", True)
 
     for conf in config.get(CONF_ON_STREAM_START, []):

--- a/esphome/components/esp32_camera/__init__.py
+++ b/esphome/components/esp32_camera/__init__.py
@@ -129,9 +129,9 @@ CONF_AGC_MODE = "agc_mode"
 CONF_AGC_VALUE = "agc_value"
 CONF_AGC_GAIN_CEILING = "agc_gain_ceiling"
 # white balance
-CONF_NIGHT_MODE = "night_mode"
-# white balance
 CONF_WB_MODE = "wb_mode"
+# night mode
+CONF_NIGHT_MODE = "night_mode"
 # test pattern
 CONF_TEST_PATTERN = "test_pattern"
 # framerates
@@ -201,7 +201,7 @@ CONFIG_SCHEMA = cv.ENTITY_BASE_SCHEMA.extend(
         # white balance
         cv.Optional(CONF_WB_MODE, default="AUTO"): cv.enum(ENUM_WB_MODE, upper=True),
         # night mode
-        cv.Optional(CONF_NIGHT_MODE, default=0): cv.int_range(min=0, max=2),
+        cv.Optional(CONF_NIGHT_MODE, default=0): cv.int_range(min=0, max=1),
         # test pattern
         cv.Optional(CONF_TEST_PATTERN, default=False): cv.boolean,
         # framerates

--- a/esphome/components/esp32_camera/__init__.py
+++ b/esphome/components/esp32_camera/__init__.py
@@ -129,6 +129,8 @@ CONF_AGC_MODE = "agc_mode"
 CONF_AGC_VALUE = "agc_value"
 CONF_AGC_GAIN_CEILING = "agc_gain_ceiling"
 # white balance
+CONF_NIGHT_MODE = "night_mode"
+# white balance
 CONF_WB_MODE = "wb_mode"
 # test pattern
 CONF_TEST_PATTERN = "test_pattern"
@@ -198,6 +200,8 @@ CONFIG_SCHEMA = cv.ENTITY_BASE_SCHEMA.extend(
         ),
         # white balance
         cv.Optional(CONF_WB_MODE, default="AUTO"): cv.enum(ENUM_WB_MODE, upper=True),
+        # night mode
+        cv.Optional(CONF_NIGHT_MODE, default=0): cv.int_range(min=0, max=2),
         # test pattern
         cv.Optional(CONF_TEST_PATTERN, default=False): cv.boolean,
         # framerates
@@ -251,6 +255,8 @@ SETTERS = {
     CONF_AGC_GAIN_CEILING: "set_agc_gain_ceiling",
     # white balance
     CONF_WB_MODE: "set_wb_mode",
+    # night mode
+    CONF_NIGHT_MODE: "set_night_mode",
     # test pattern
     CONF_TEST_PATTERN: "set_test_pattern",
 }

--- a/esphome/components/esp32_camera/esp32_camera.cpp
+++ b/esphome/components/esp32_camera/esp32_camera.cpp
@@ -135,7 +135,7 @@ void ESP32Camera::dump_config() {
   ESP_LOGCONFIG(TAG, "  Horizontal Mirror: %s", ONOFF(st.hmirror));
   ESP_LOGCONFIG(TAG, "  Special Effect: %u", st.special_effect);
   ESP_LOGCONFIG(TAG, "  White Balance Mode: %u", st.wb_mode);
-  ESP_LOGCONFIG(TAG, "  Night Mode: %d", s.get_reg(s, 0x10f, 0xff) == 0x4b ? 1 : 0);
+  ESP_LOGCONFIG(TAG, "  Night Mode: %d", s->get_reg(s, 0x10f, 0xff) == 0x4b ? 1 : 0);
   // ESP_LOGCONFIG(TAG, "  Auto White Balance: %u", st.awb);
   // ESP_LOGCONFIG(TAG, "  Auto White Balance Gain: %u", st.awb_gain);
   ESP_LOGCONFIG(TAG, "  Auto Exposure Control: %u", st.aec);

--- a/esphome/components/esp32_camera/esp32_camera.cpp
+++ b/esphome/components/esp32_camera/esp32_camera.cpp
@@ -325,6 +325,7 @@ void ESP32Camera::set_agc_value(uint8_t agc_value) { this->agc_value_ = agc_valu
 void ESP32Camera::set_agc_gain_ceiling(ESP32AgcGainCeiling gain_ceiling) { this->agc_gain_ceiling_ = gain_ceiling; }
 /* set white balance */
 void ESP32Camera::set_wb_mode(ESP32WhiteBalanceMode mode) { this->wb_mode_ = mode; }
+/* set night mode */
 void ESP32Camera::set_night_mode(uint8_t mode) { this->night_mode_ = mode; }
 /* set test mode */
 void ESP32Camera::set_test_pattern(bool test_pattern) { this->test_pattern_ = test_pattern; }

--- a/esphome/components/esp32_camera/esp32_camera.cpp
+++ b/esphome/components/esp32_camera/esp32_camera.cpp
@@ -36,7 +36,7 @@ void ESP32Camera::setup() {
       return;
     }
   }
-  ESP_LOGE(TAG, "esp_camera_init success");
+  ESP_LOGD(TAG, "esp_camera_init success");
 
   /* initialize camera parameters */
   this->update_camera_parameters();

--- a/esphome/components/esp32_camera/esp32_camera.cpp
+++ b/esphome/components/esp32_camera/esp32_camera.cpp
@@ -135,6 +135,7 @@ void ESP32Camera::dump_config() {
   ESP_LOGCONFIG(TAG, "  Horizontal Mirror: %s", ONOFF(st.hmirror));
   ESP_LOGCONFIG(TAG, "  Special Effect: %u", st.special_effect);
   ESP_LOGCONFIG(TAG, "  White Balance Mode: %u", st.wb_mode);
+  ESP_LOGCONFIG(TAG, "  Night Mode: %u", st.night_mode);
   // ESP_LOGCONFIG(TAG, "  Auto White Balance: %u", st.awb);
   // ESP_LOGCONFIG(TAG, "  Auto White Balance Gain: %u", st.awb_gain);
   ESP_LOGCONFIG(TAG, "  Auto Exposure Control: %u", st.aec);
@@ -324,6 +325,7 @@ void ESP32Camera::set_agc_value(uint8_t agc_value) { this->agc_value_ = agc_valu
 void ESP32Camera::set_agc_gain_ceiling(ESP32AgcGainCeiling gain_ceiling) { this->agc_gain_ceiling_ = gain_ceiling; }
 /* set white balance */
 void ESP32Camera::set_wb_mode(ESP32WhiteBalanceMode mode) { this->wb_mode_ = mode; }
+void ESP32Camera::set_night_mode(uint8_t mode) { this->night_mode_ = mode; }
 /* set test mode */
 void ESP32Camera::set_test_pattern(bool test_pattern) { this->test_pattern_ = test_pattern; }
 /* set fps */
@@ -373,6 +375,7 @@ void ESP32Camera::update_camera_parameters() {
   s->set_gainceiling(s, (gainceiling_t) this->agc_gain_ceiling_);
   /* update white balance mode */
   s->set_wb_mode(s, (int) this->wb_mode_);  // 0 to 4
+  s->set_night_mode(s, (int) this->night_mode_);  // 0 to 2
   /* update test pattern */
   s->set_colorbar(s, this->test_pattern_);
 }

--- a/esphome/components/esp32_camera/esp32_camera.cpp
+++ b/esphome/components/esp32_camera/esp32_camera.cpp
@@ -22,10 +22,21 @@ void ESP32Camera::setup() {
   esp_err_t err = esp_camera_init(&this->config_);
   if (err != ESP_OK) {
     ESP_LOGE(TAG, "esp_camera_init failed: %s", esp_err_to_name(err));
-    this->init_error_ = err;
-    this->mark_failed();
-    return;
+
+    ESP_LOGE(TAG, "waiting 1 sec");
+    delay(1000);  // 1 sec
+    ESP_LOGE(TAG, "trying again");
+    esp_err_t err = esp_camera_init(&this->config_);
+
+    if (err != ESP_OK) {
+      ESP_LOGE(TAG, "esp_camera_init failed multiple times: %s", esp_err_to_name(err));
+
+      this->init_error_ = err;
+      this->mark_failed();
+      return;
+    }
   }
+  ESP_LOGE(TAG, "esp_camera_init success");
 
   /* initialize camera parameters */
   this->update_camera_parameters();

--- a/esphome/components/esp32_camera/esp32_camera.cpp
+++ b/esphome/components/esp32_camera/esp32_camera.cpp
@@ -18,6 +18,7 @@ void ESP32Camera::setup() {
   /* initialize time to now */
   this->last_update_ = millis();
 
+  ESP_LOGD(TAG, "calling esp_camera_init");
   /* initialize camera */
   esp_err_t err = esp_camera_init(&this->config_);
   if (err != ESP_OK) {

--- a/esphome/components/esp32_camera/esp32_camera.cpp
+++ b/esphome/components/esp32_camera/esp32_camera.cpp
@@ -135,7 +135,8 @@ void ESP32Camera::dump_config() {
   ESP_LOGCONFIG(TAG, "  Horizontal Mirror: %s", ONOFF(st.hmirror));
   ESP_LOGCONFIG(TAG, "  Special Effect: %u", st.special_effect);
   ESP_LOGCONFIG(TAG, "  White Balance Mode: %u", st.wb_mode);
-  ESP_LOGCONFIG(TAG, "  Night Mode: %u", st.night_mode);
+  // ESP_LOGCONFIG(TAG, "  Night Mode: %u", st.night_mode);
+  ESP_LOGCONFIG(TAG, "  Night Mode: unknown? FIXME");
   // ESP_LOGCONFIG(TAG, "  Auto White Balance: %u", st.awb);
   // ESP_LOGCONFIG(TAG, "  Auto White Balance Gain: %u", st.awb_gain);
   ESP_LOGCONFIG(TAG, "  Auto Exposure Control: %u", st.aec);
@@ -375,7 +376,23 @@ void ESP32Camera::update_camera_parameters() {
   s->set_gainceiling(s, (gainceiling_t) this->agc_gain_ceiling_);
   /* update white balance mode */
   s->set_wb_mode(s, (int) this->wb_mode_);  // 0 to 4
-  s->set_night_mode(s, (int) this->night_mode_);  // 0 to 2
+
+
+  // s->set_night_mode(s, (int) this->night_mode_);  // 0 to 2
+// FIXME direct register write?
+  // int  (*set_reg)             (sensor_t *sensor, int reg, int mask, int value);
+  if (this->night_mode_ == 0) {
+    // COM1 = 0x103
+    // RSVD = 0x10f
+      s->set_reg(s, 0x103, 0xff, 0x0a);  // COM1: Reset dummy frames
+      s->set_reg(s, 0x10f, 0xff, 0x43);
+  } else if (this->night_mode_ == 2) {
+      s->set_reg(s, 0x10f, 0xff, 0x4b); // enable nightmode
+      s->set_reg(s, 0x103, 0xff, 0xcf);  // COM1: Set dummy frames to 7
+  }
+  // FIXME mode 1?
+
+
   /* update test pattern */
   s->set_colorbar(s, this->test_pattern_);
 }

--- a/esphome/components/esp32_camera/esp32_camera.h
+++ b/esphome/components/esp32_camera/esp32_camera.h
@@ -135,6 +135,8 @@ class ESP32Camera : public Component, public EntityBase {
   void set_agc_gain_ceiling(ESP32AgcGainCeiling gain_ceiling);
   /* -- white balance */
   void set_wb_mode(ESP32WhiteBalanceMode mode);
+  /* -- night mode */
+  void set_night_mode(uint8_t mode);
   /* -- test */
   void set_test_pattern(bool test_pattern);
   /* -- framerates */
@@ -184,6 +186,7 @@ class ESP32Camera : public Component, public EntityBase {
   ESP32AgcGainCeiling agc_gain_ceiling_{ESP32_GAINCEILING_2X};
   /* -- white balance */
   ESP32WhiteBalanceMode wb_mode_{ESP32_WB_MODE_AUTO};
+  uint8_t night_mode_{0};
   /* -- Test */
   bool test_pattern_{false};
   /* -- framerates */

--- a/esphome/components/esp32_camera/esp32_camera.h
+++ b/esphome/components/esp32_camera/esp32_camera.h
@@ -186,6 +186,7 @@ class ESP32Camera : public Component, public EntityBase {
   ESP32AgcGainCeiling agc_gain_ceiling_{ESP32_GAINCEILING_2X};
   /* -- white balance */
   ESP32WhiteBalanceMode wb_mode_{ESP32_WB_MODE_AUTO};
+  /* -- night mode */
   uint8_t night_mode_{0};
   /* -- Test */
   bool test_pattern_{false};

--- a/platformio.ini
+++ b/platformio.ini
@@ -140,7 +140,7 @@ platform_packages =
 framework = espidf
 lib_deps =
     ${common:idf.lib_deps}
-    misch2/esp32-camera@ov2640-nightmode  ; esp32_camera
+    esp32_camera
 build_flags =
     ${common:idf.build_flags}
     -Wno-nonnull-compare

--- a/platformio.ini
+++ b/platformio.ini
@@ -140,7 +140,7 @@ platform_packages =
 framework = espidf
 lib_deps =
     ${common:idf.lib_deps}
-    espressif/esp32-camera@1.0.0  ; esp32_camera
+    misch2/esp32-camera@ov2640-nightmode  ; esp32_camera
 build_flags =
     ${common:idf.build_flags}
     -Wno-nonnull-compare


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
external_components:
  - source: github://misch2/esphome@camera-nightmode
    components: [ esp32_camera ]

esp32_camera:
  night_mode: 1
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
